### PR TITLE
Allow custom field name and target path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Include the version of your package in our source code.
     `lib/src/version.dart` will be generated with content:
 
     ```dart
-    // Generated code. Do not modify.
-    const packageVersion = '1.2.3';
+    /// Generated code. Do not modify.
+    const String packageVersion = '1.2.3';
     ```

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -12,7 +12,7 @@ import 'dart:async';
 import 'package:build/build.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-Builder buildVersion([BuilderOptions options]) => _VersionBuilder();
+Builder buildVersion([BuilderOptions options]) => _VersionBuilder(options);
 
 // The top level keys supported for the `options` config for the [_VersionBuilder].
 const String _fieldName = 'field_name';

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -15,8 +15,8 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 Builder buildVersion([BuilderOptions options]) => _VersionBuilder();
 
 // The top level keys supported for the `options` config for the [_VersionBuilder].
-const String _fieldName = 'fieldName';
-const String _targetPath = 'targetPath';
+const String _fieldName = 'field_name';
+const String _targetPath = 'target_path';
 
 class _VersionBuilder implements Builder {
   _VersionBuilder([BuilderOptions options])

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -14,7 +14,22 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 
 Builder buildVersion([BuilderOptions options]) => _VersionBuilder();
 
+// The top level keys supported for the `options` config for the [_VersionBuilder].
+const String _fieldName = 'fieldName';
+const String _targetPath = 'targetPath';
+
 class _VersionBuilder implements Builder {
+  _VersionBuilder([BuilderOptions options])
+      : fieldName = options != null && options.config.containsKey(_fieldName)
+            ? options.config[_fieldName].toString()
+            : 'packageVersion',
+        targetPath = options != null && options.config.containsKey(_targetPath)
+            ? options.config[_targetPath].toString()
+            : 'src/version.dart';
+
+  final String fieldName;
+  final String targetPath;
+
   @override
   Future build(BuildStep buildStep) async {
     var assetId = AssetId(buildStep.inputId.package, 'pubspec.yaml');
@@ -28,14 +43,14 @@ class _VersionBuilder implements Builder {
     }
 
     await buildStep.writeAsString(
-        AssetId(buildStep.inputId.package, 'lib/src/version.dart'), '''
-// Generated code. Do not modify.
-const packageVersion = '${pubspec.version}';
+        AssetId(buildStep.inputId.package, 'lib/$targetPath'), '''
+/// Generated code. Do not modify.
+const String $fieldName = '${pubspec.version}';
 ''');
   }
 
   @override
-  final buildExtensions = const {
-    r'$lib$': ['src/version.dart']
-  };
+  Map<String, List<String>> get buildExtensions => {
+        r'$lib$': [targetPath]
+      };
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
-// Generated code. Do not modify.
-const packageVersion = '2.0.0';
+/// Generated code. Do not modify.
+const String packageVersion = '2.0.0';

--- a/test/build_version_test.dart
+++ b/test/build_version_test.dart
@@ -31,8 +31,8 @@ void main() {
         buildVersion(), _createPackageStub({'name': 'pkg', 'version': '1.0.0'}),
         outputs: {
           'pkg|lib/src/version.dart': (r'''
-// Generated code. Do not modify.
-const packageVersion = '1.0.0';
+/// Generated code. Do not modify.
+const String packageVersion = '1.0.0';
 ''')
         });
   });


### PR DESCRIPTION
A very quick and naive fix for #2 and #3.

The name of the generated field is free.
The path of the generated file must be relative to the `lib` folder.
