### PR TITLE
Custom field name and part file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.0
+
+- Users can now customize the version constant name and the generated 
+  version file could be a part of an existing package library.
+
 ## 2.0.0
 
 - The builder now runs when `build_version` is a dependency. `build.yaml`

--- a/README.md
+++ b/README.md
@@ -26,3 +26,47 @@ Include the version of your package in our source code.
     // Generated code. Do not modify.
     const packageVersion = '1.2.3';
     ```
+
+3. To customize the name of the version constant, a `build.yaml` option can be used.
+
+    ```yaml
+    targets:
+      $default:
+        builders:
+          build_version:
+            options:
+              field_name: 'myVersion' # defaults to 'packageVersion'
+    ```
+    
+4. It is also possible to generate the version string as a part of an existing library 
+   in your package. In such a case, the default version builder needs to be disabled and 
+   the version part builder should be used.
+   
+    ```yaml
+    targets:
+      $default:
+        builders:
+          build_version:
+            enabled: false
+          build_version|build_version_part:
+            enabled: true
+            generate_for: ['lib/src/my_lib.dart']
+            options:
+              field_name: 'myLibraryVersion' # defaults to 'packageVersion'
+    ```
+
+   Assuming that `lib/src/my_lib.dart` contains `part 'my_lib.version.g.dart';`,
+   `lib/src/my_lib.version.g.dart` will be generated with content:
+
+    ```dart
+    // GENERATED CODE - DO NOT MODIFY BY HAND
+    
+    part of 'my_lib.dart';
+    
+    // **************************************************************************
+    // _VersionPartGenerator
+    // **************************************************************************
+    
+    // Generated code. Do not modify.
+    const packageVersion = '1.2.3';
+    ```

--- a/build.yaml
+++ b/build.yaml
@@ -12,3 +12,8 @@ builders:
     build_extensions: {"$lib$": ["version.dart"]}
     build_to: source
     auto_apply: dependents
+  build_version_part:
+    import: "package:build_version/builder.dart"
+    builder_factories: ["buildVersionPart"]
+    build_extensions: {"$lib$": [".version.g.dart"]}
+    build_to: source

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -8,34 +8,58 @@
 library builder;
 
 import 'dart:async';
-
 import 'package:build/build.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:source_gen/source_gen.dart';
 
-Builder buildVersion([BuilderOptions options]) => _VersionBuilder();
+Builder buildVersion([BuilderOptions options]) => _VersionBuilder(options);
+
+Builder buildVersionPart([BuilderOptions options]) => PartBuilder(
+    [_VersionPartGenerator(_fieldName(options))], '.version.g.dart');
+
+String _fieldName(BuilderOptions options) =>
+    options != null && options.config.containsKey('field_name')
+        ? options.config['field_name'] as String
+        : 'packageVersion';
 
 class _VersionBuilder implements Builder {
+  _VersionBuilder([BuilderOptions options]) : fieldName = _fieldName(options);
+
+  final String fieldName;
+
   @override
   Future build(BuildStep buildStep) async {
-    final assetId = AssetId(buildStep.inputId.package, 'pubspec.yaml');
-
-    final content = await buildStep.readAsString(assetId);
-
-    final pubspec = Pubspec.parse(content, sourceUrl: assetId.uri);
-
-    if (pubspec.version == null) {
-      throw StateError('pubspec.yaml does not have a version defined.');
-    }
-
     await buildStep.writeAsString(
-        AssetId(buildStep.inputId.package, 'lib/src/version.dart'), '''
-// Generated code. Do not modify.
-const packageVersion = '${pubspec.version}';
-''');
+        AssetId(buildStep.inputId.package, 'lib/src/version.dart'),
+        await _versionSource(buildStep, fieldName));
   }
 
   @override
   final buildExtensions = const {
     r'$lib$': ['src/version.dart']
   };
+}
+
+class _VersionPartGenerator extends Generator {
+  _VersionPartGenerator(this.fieldName);
+
+  final String fieldName;
+
+  @override
+  Future<String> generate(LibraryReader library, BuildStep buildStep) async =>
+      _versionSource(buildStep, fieldName);
+}
+
+Future<String> _versionSource(BuildStep buildStep, String fieldName) async {
+  final assetId = AssetId(buildStep.inputId.package, 'pubspec.yaml');
+  final content = await buildStep.readAsString(assetId);
+  final pubspec = Pubspec.parse(content, sourceUrl: assetId.uri);
+
+  if (pubspec.version == null) {
+    throw StateError('pubspec.yaml does not have a version defined.');
+  }
+  return '''
+// Generated code. Do not modify.
+const $fieldName = '${pubspec.version}';
+''';
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.0';
+const packageVersion = '2.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: build_version
 description: A builder for extracting a package version into code.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/kevmoo/build_version
 author: Kevin Moore <kevmoo@google.com>
 
@@ -12,6 +12,7 @@ dependencies:
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ^0.3.0
   pubspec_parse: ^0.1.2+2
+  source_gen: ^0.9.4
 
 dev_dependencies:
   build_runner: ^1.0.0

--- a/test/build_version_test.dart
+++ b/test/build_version_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:build_version/builder.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
@@ -33,6 +34,17 @@ void main() {
           'pkg|lib/src/version.dart': r'''
 // Generated code. Do not modify.
 const packageVersion = '1.0.0';
+'''
+        });
+  });
+  test('valid input with custom field', () async {
+    await testBuilder(
+        buildVersion(const BuilderOptions({'field_name': 'myVersion'})),
+        _createPackageStub({'name': 'pkg', 'version': '1.0.0'}),
+        outputs: {
+          'pkg|lib/src/version.dart': r'''
+// Generated code. Do not modify.
+const myVersion = '1.0.0';
 '''
         });
   });


### PR DESCRIPTION
Fixes #3 and allows changing the location / name of the generated file via `part` declarations using `source_gen` (fixes #4).

@kevmoo PTAL.