### PR TITLE
Use correct generated file location in build.yaml

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -9,6 +9,6 @@ builders:
   build_version:
     import: "package:build_version/builder.dart"
     builder_factories: ["buildVersion"]
-    build_extensions: {"$lib$": ["version.dart"]}
+    build_extensions: {"$lib$": ["src/version.dart"]}
     build_to: source
     auto_apply: dependents


### PR DESCRIPTION
Hey! Just found your package, looked into the `build.yaml` to find out where the generated file is placed, and was confused that the `import` couldn't be resolved.
Best regards!