### PR TITLE
Make output path configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Make the path of the generated output configurable
+
 ## 2.0.3
 
 - Support the latest `package:build_config`.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Include the version of your package in our source code.
 2. Run a build.
 
     ```console
-    > pub run build_runner build
+    > dart pub run build_runner build
     ```
 
     `lib/src/version.dart` will be generated with content:
@@ -25,3 +25,18 @@ Include the version of your package in our source code.
     // Generated code. Do not modify.
     const packageVersion = '1.2.3';
     ```
+
+To change the path of the generated file, create a [`build.yaml`](build config)
+in the root of your package.
+My changing the `output` option of this builder, the path can be customized:
+
+```yaml
+targets:
+  $default:
+    builders:
+      build_version:
+        options:
+          output: lib/src/custom/path/to/version.dart
+```
+
+[build config]: https://pub.dev/packages/build_config

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Include the version of your package in our source code.
 
 To change the path of the generated file, create a [`build.yaml`](build config)
 in the root of your package.
-My changing the `output` option of this builder, the path can be customized:
+By changing the `output` option of this builder, the path can be customized:
 
 ```yaml
 targets:

--- a/build.yaml
+++ b/build.yaml
@@ -9,6 +9,9 @@ builders:
   build_version:
     import: "package:build_version/builder.dart"
     builder_factories: ["buildVersion"]
-    build_extensions: {"$lib$": ["src/version.dart"]}
+    build_extensions: {"pubspec.yaml": ["lib/src/version.dart"]}
+    defaults:
+      options:
+        output: "lib/src/version.dart"
     build_to: source
     auto_apply: dependents

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -15,7 +15,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 const _defaultOutput = 'lib/src/version.dart';
 
 Builder buildVersion([BuilderOptions? options]) =>
-    _VersionBuilder((options?.config['output'] ?? _defaultOutput) as String);
+    _VersionBuilder((options?.config['output'] as String?) ?? _defaultOutput);
 
 class _VersionBuilder implements Builder {
   final String output;

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -12,9 +12,16 @@ import 'dart:async';
 import 'package:build/build.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-Builder buildVersion([BuilderOptions? options]) => _VersionBuilder();
+const _defaultOutput = 'lib/src/version.dart';
+
+Builder buildVersion([BuilderOptions? options]) =>
+    _VersionBuilder((options?.config['output'] ?? _defaultOutput) as String);
 
 class _VersionBuilder implements Builder {
+  final String output;
+
+  _VersionBuilder(this.output);
+
   @override
   Future build(BuildStep buildStep) async {
     final assetId = AssetId(buildStep.inputId.package, 'pubspec.yaml');
@@ -27,15 +34,14 @@ class _VersionBuilder implements Builder {
       throw StateError('pubspec.yaml does not have a version defined.');
     }
 
-    await buildStep.writeAsString(
-        AssetId(buildStep.inputId.package, 'lib/src/version.dart'), '''
+    await buildStep.writeAsString(buildStep.allowedOutputs.single, '''
 // Generated code. Do not modify.
 const packageVersion = '${pubspec.version}';
 ''');
   }
 
   @override
-  final buildExtensions = const {
-    r'$lib$': ['src/version.dart']
-  };
+  Map<String, List<String>> get buildExtensions => {
+        'pubspec.yaml': [output],
+      };
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '2.0.3';
+const packageVersion = '2.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: build_version
 description: A builder for extracting a package version into code.
-version: 2.0.3
+version: 2.1.0
 repository: https://github.com/kevmoo/build_version
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  build: ^2.0.0
+  build: ^2.1.0
   # Not imported in code, but used to constrain `build.yaml` requirements
   build_config: ^1.0.0
   pubspec_parse: ^1.0.0

--- a/test/build_version_test.dart
+++ b/test/build_version_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:build/build.dart';
 import 'package:build_test/build_test.dart';
 import 'package:build_version/builder.dart';
 import 'package:checked_yaml/checked_yaml.dart';
@@ -35,6 +36,19 @@ void main() {
 const packageVersion = '1.0.0';
 '''
         });
+  });
+
+  test('valid input, custom output location', () async {
+    await testBuilder(
+      buildVersion(const BuilderOptions({'output': 'bin/version.dart'})),
+      _createPackageStub({'name': 'pkg', 'version': '1.0.0'}),
+      outputs: {
+        'pkg|bin/version.dart': r'''
+// Generated code. Do not modify.
+const packageVersion = '1.0.0';
+'''
+      },
+    );
   });
 }
 


### PR DESCRIPTION
Add a builder option to make the generated path configurable.

Closes #2.